### PR TITLE
Highlight current symbol with current plugin face

### DIFF
--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -1239,11 +1239,11 @@ You can do these operations at One Key!
 
 (defun ahs-highlight-current-symbol (current beg end)
   "Highlight current symbol."
-  (let* ((overlay (make-overlay beg end nil nil t)))
-
+  (let* ((overlay (make-overlay beg end nil nil t))
+         (face (ahs-current-plugin-prop 'face)))
     (overlay-put overlay 'ahs-symbol 'current)
     (overlay-put overlay 'priority ahs-overlay-priority)
-    (overlay-put overlay 'face (if current ahs-plugin-default-face ahs-plugin-default-face-unfocused))
+    (overlay-put overlay 'face face)
     (overlay-put overlay 'help-echo '(ahs-stat-string))
     (overlay-put overlay 'window (selected-window))
 


### PR DESCRIPTION
`auto-highlight-symbol` defines three plugins, each with its own face. However, the current symbol is highlighted only with the "display" plugin's face. This PR makes that highlighting aware of the current plugin. Thank you for considering this change!

The other faces don't define `-unfocused` faces, and `ahs-plugin-default-face-unfocused` is identical to `ahs-plugin-default-face` anyway, so the proposed face is no longer dependent on the parameter "`current`".

If it's relevant, the context for this change is that I recently discovered that my package, [`symbol-navigation-hydra`](http://github.com/bgwines/symbol-navigation-hydra/), was depending on an old version of `auto-highlight-symbol`. During the process of upgrading, I noticed that switching the current plugin did not update the overlay face. You can see the old behavior in the screenshots in that repo's README, so I believe this might be a regression introduced in 1.61: https://github.com/jcs-elpa/auto-highlight-symbol/commit/7d7d89aa16d4f09f18dac15a6f594ba5b1dba443#diff-e7a9435d360fadbeb259c0d4db30503bbaf19ae209f140595f61ac60279d9ba6L1162