### PR TITLE
Define variable to highlight current window only

### DIFF
--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -484,6 +484,13 @@ Affects only overlay(hidden text) has a property `isearch-open-invisible'."
 ;; (@* "Highlight Rules" )
 ;;
 
+(defcustom ahs-highlight-all-windows t
+  "*Non-nil means symbols in all windows candidates for highlighting.
+
+Otherwise, the only window that is considered is the current one."
+  :group 'auto-highlight-symbol
+  :type 'boolean)
+
 (defcustom ahs-case-fold-search t
   "*Non-nil means symbol search ignores case."
   :group 'auto-highlight-symbol
@@ -1016,7 +1023,9 @@ You can do these operations at One Key!
 (defun ahs-idle-function ()
   "Idle function. Called by `ahs-idle-timer'."
   (setq ahs-selected-window (selected-window))
-  (walk-windows (lambda (win) (with-selected-window win (ahs--do-hl)))))
+  (if ahs-highlight-all-windows
+      (walk-windows (lambda (win) (with-selected-window win (ahs--do-hl))))
+    (ahs--do-hl)))
 
 (defun ahs--do-hl ()
   "Do the highlighting."

--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -1717,8 +1717,8 @@ That's all."
 (defun ahs-unfocus-all ()
   "Unfocus all windows."
   (interactive)
-  (setq ahs-selected-window nil)
-  (walk-windows (lambda (win) (with-selected-window win (ahs--do-hl)))))
+  (ahs-idle-function)
+  (setq ahs-selected-window nil))
 
 (defun ahs-goto-web ()
   "Go to official? web site."


### PR DESCRIPTION
I believe before 1.61 only the current window was highlighted:
https://github.com/jcs-elpa/auto-highlight-symbol/commit/b3674dd553e49a52f9a0ebb2085446ac9ac7b7c4#diff-e7a9435d360fadbeb259c0d4db30503bbaf19ae209f140595f61ac60279d9ba6R942

This PR introduces a way to restore that ability, but preserves the 1.61
behavior as the default.

No pressure to adopt this, of course, if this isn't the direction you want your
package to go <3 I'm totally happy to maintain a fork for myself since I
understand my use-cases may be a bit different from your other users!