### PR TITLE
Define variable to not highlight upon window switch

### DIFF
--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -484,6 +484,11 @@ Affects only overlay(hidden text) has a property `isearch-open-invisible'."
 ;; (@* "Highlight Rules" )
 ;;
 
+(defcustom ahs-highlight-upon-window-switch t
+  "*Non-nil means rehighlighting is triggered upon window switch."
+  :group 'auto-highlight-symbol
+  :type 'boolean)
+
 (defcustom ahs-case-fold-search t
   "*Non-nil means symbol search ignores case."
   :group 'auto-highlight-symbol
@@ -1005,8 +1010,11 @@ You can do these operations at One Key!
     (when (timerp ahs-idle-timer) (cancel-timer ahs-idle-timer))
     (setq ahs-idle-timer
           (run-with-timer
-           ;; if switch window, immediately change focus/unfocus
-           (if (eq ahs-selected-window (selected-window)) ahs-idle-interval 0)
+           ;; if switch window, immediately change focus/unfocus unless the user
+           ;; doesn't want us to
+           (if (or (eq ahs-selected-window (selected-window))
+                   (not ahs-highlight-upon-window-switch))
+               ahs-idle-interval 0)
            nil #'ahs-idle-function))))
 
 ;;


### PR DESCRIPTION
I believe before 1.61 focus-switching would not trigger highlighting:
https://github.com/jcs-elpa/auto-highlight-symbol/commit/a79ce27346dc658379df0adf4e0e758d29437bc5

This PR introduces a way to restore that ability, but preserves the 1.61
behavior as the default.

No pressure to adopt this, of course, if this isn't the direction you want your
package to go <3 I'm totally happy to maintain a fork for myself since I
understand my use-cases may be a bit different from your other users!

As context, my use-case is to trigger highlighting only upon invocation of the
[`symbol-navigation-hydra`](https://github.com/bgwines/symbol-navigation-hydra).