### PR TITLE
Define variable to en/disable focus hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 
+## v1.63 (Unreleased)
+> Released N/A
+
+* introduce new variable `ahs-enable-focus-hooks' to enable/disable focus hooks
+
+
 ## v1.62 (Unreleased)
 > Released N/A
 

--- a/auto-highlight-symbol.el
+++ b/auto-highlight-symbol.el
@@ -157,6 +157,8 @@
 ;;    *Non-nil means symbol search ignores case.
 ;;  `ahs-highlight-upon-window-switch'
 ;;    *Non-nil means rehighlighting is triggered upon window switch.
+;;  `ahs-enable-focus-hooks'
+;;    *Non-nil means focus-in and focus-out hooks will run.
 ;;  `ahs-include'
 ;;    Variable for start highlighting.
 ;;  `ahs-exclude'
@@ -424,6 +426,11 @@ Otherwise, the only window that is considered is the current one."
 
 (defcustom ahs-highlight-upon-window-switch t
   "*Non-nil means rehighlighting is triggered upon window switch."
+  :group 'auto-highlight-symbol
+  :type 'boolean)
+
+(defcustom ahs-enable-focus-hooks t
+  "Toggles whether to enable focus-in and focus-out hooks"
   :group 'auto-highlight-symbol
   :type 'boolean)
 
@@ -1704,11 +1711,13 @@ buffer' temporary."
 
 (defun ahs-focus-in (&rest _)
   "Focus in hook."
-  (ahs-highlight-now))
+  (when ahs-enable-focus-hooks
+    (ahs-highlight-now)))
 
 (defun ahs-focus-out (&rest _)
   "Focus out hook."
-  (ahs-unfocus-all))
+  (when ahs-enable-focus-hooks
+    (ahs-unfocus-all)))
 
 (if (< emacs-major-version 27)
     (with-no-warnings


### PR DESCRIPTION
Hi! Thanks for considering this change <3

Currently, when I cmd-tab away from Emacs to another application, symbols are highlighted. I'd like to have the ability to disable that -- similarly to https://github.com/jcs-elpa/auto-highlight-symbol/pull/15 , I want to trigger highlighting only upon invocation of the [`symbol-navigation-hydra`](https://github.com/bgwines/symbol-navigation-hydra).

The default behavior remains unchanged: focus hooks are enabled by default.

I saw you updated the `CHANGELOG` for my other PRs -- I've tried to save you that effort this time, but apologies if I did it incorrectly. Thanks so much!